### PR TITLE
Add custom cache-control header option

### DIFF
--- a/lambda_proxy/proxy.py
+++ b/lambda_proxy/proxy.py
@@ -580,6 +580,8 @@ class API(object):
                 )
 
         if ttl:
+            from warnings import warn
+            warn("ttl will be deprecated in 6.0.0", DeprecationWarning, stacklevel=2)
             messageData["headers"]["Cache-Control"] = (
                 f"max-age={ttl}" if status == "OK" else "no-cache"
             )

--- a/lambda_proxy/proxy.py
+++ b/lambda_proxy/proxy.py
@@ -581,6 +581,7 @@ class API(object):
 
         if ttl:
             from warnings import warn
+
             warn("ttl will be deprecated in 6.0.0", DeprecationWarning, stacklevel=2)
             messageData["headers"]["Cache-Control"] = (
                 f"max-age={ttl}" if status == "OK" else "no-cache"

--- a/lambda_proxy/proxy.py
+++ b/lambda_proxy/proxy.py
@@ -87,6 +87,7 @@ class RouteEntry(object):
         payload_compression_method: str = "",
         binary_b64encode: bool = False,
         ttl=None,
+        cache_control=None,
         description: str = None,
         tag: Tuple = None,
     ) -> None:
@@ -101,6 +102,7 @@ class RouteEntry(object):
         self.compression = payload_compression_method
         self.b64encode = binary_b64encode
         self.ttl = ttl
+        self.cache_control = cache_control
         self.description = description or self.endpoint.__doc__
         self.tag = tag
         if self.compression and self.compression not in ["gzip", "zlib", "deflate"]:
@@ -362,6 +364,7 @@ class API(object):
         payload_compression = kwargs.pop("payload_compression_method", "")
         binary_encode = kwargs.pop("binary_b64encode", False)
         ttl = kwargs.pop("ttl", None)
+        cache_control = kwargs.pop("cache_control", None)
         description = kwargs.pop("description", None)
         tag = kwargs.pop("tag", None)
 
@@ -386,6 +389,7 @@ class API(object):
             payload_compression,
             binary_encode,
             ttl,
+            cache_control,
             description,
             tag,
         )
@@ -504,6 +508,7 @@ class API(object):
         compression: str = "",
         b64encode: bool = False,
         ttl: int = None,
+        cache_control: str = None,
     ):
         """Return HTTP response.
 
@@ -577,6 +582,10 @@ class API(object):
         if ttl:
             messageData["headers"]["Cache-Control"] = (
                 f"max-age={ttl}" if status == "OK" else "no-cache"
+            )
+        elif cache_control:
+            messageData["headers"]["Cache-Control"] = (
+                cache_control if status == "OK" else "no-cache"
             )
 
         if (
@@ -676,4 +685,5 @@ class API(object):
             compression=route_entry.compression,
             b64encode=route_entry.b64encode,
             ttl=route_entry.ttl,
+            cache_control=route_entry.cache_control,
         )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -332,10 +332,20 @@ def test_cache_control():
     app = proxy.API(name="test")
     funct = Mock(__name__="Mock", return_value=("OK", "text/plain", "heyyyy"))
     app._add_route(
-        "/test/<string:user>/<name>", funct, methods=["GET"], cors=True, cache_control='public,max-age=3600'
+        "/test/<string:user>/<name>",
+        funct,
+        methods=["GET"],
+        cors=True,
+        cache_control="public,max-age=3600",
     )
     funct_error = Mock(__name__="Mock", return_value=("NOK", "text/plain", "heyyyy"))
-    app._add_route("/yo", funct_error, methods=["GET"], cors=True, cache_control='public,max-age=3600')
+    app._add_route(
+        "/yo",
+        funct_error,
+        methods=["GET"],
+        cors=True,
+        cache_control="public,max-age=3600",
+    )
 
     event = {
         "path": "/test/remote/pixel",

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -327,6 +327,47 @@ def test_ttl():
     assert res["headers"]["Cache-Control"] == "no-cache"
 
 
+def test_cache_control():
+    """Add and parse route."""
+    app = proxy.API(name="test")
+    funct = Mock(__name__="Mock", return_value=("OK", "text/plain", "heyyyy"))
+    app._add_route(
+        "/test/<string:user>/<name>", funct, methods=["GET"], cors=True, cache_control='public,max-age=3600'
+    )
+    funct_error = Mock(__name__="Mock", return_value=("NOK", "text/plain", "heyyyy"))
+    app._add_route("/yo", funct_error, methods=["GET"], cors=True, cache_control='public,max-age=3600')
+
+    event = {
+        "path": "/test/remote/pixel",
+        "httpMethod": "GET",
+        "headers": {},
+        "queryStringParameters": {},
+    }
+    resp = {
+        "body": "heyyyy",
+        "headers": {
+            "Access-Control-Allow-Credentials": "true",
+            "Access-Control-Allow-Methods": "GET",
+            "Access-Control-Allow-Origin": "*",
+            "Content-Type": "text/plain",
+            "Cache-Control": "public,max-age=3600",
+        },
+        "statusCode": 200,
+    }
+    res = app(event, {})
+    assert res == resp
+    funct.assert_called_with(user="remote", name="pixel")
+
+    event = {
+        "path": "/yo",
+        "httpMethod": "GET",
+        "headers": {},
+        "queryStringParameters": {},
+    }
+    res = app(event, {})
+    assert res["headers"]["Cache-Control"] == "no-cache"
+
+
 def test_querystringNull():
     """Add and parse route."""
     app = proxy.API(name="test")


### PR DESCRIPTION
Closes #32 

Essentially adds `cache_control` after each `ttl`, where the response headers are determined by 
```py
        if ttl:
            messageData["headers"]["Cache-Control"] = (
                f"max-age={ttl}" if status == "OK" else "no-cache"
            )
        elif cache_control:
            messageData["headers"]["Cache-Control"] = (
                cache_control if status == "OK" else "no-cache"
            )
```
so that `cache_control` is only used if `bool(ttl)` is `False`, which should keep backwards compatibility.