### PR TITLE
Fix handling of $default stage to support HTTP API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.serverless
+package.zip
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM lambci/lambda:build-python3.8
+
+WORKDIR /tmp
+
+ENV PYTHONUSERBASE=/var/task
+
+COPY lambda_proxy/ lambda_proxy/
+COPY README.md README.md
+COPY setup.py setup.py
+
+# Install dependencies
+RUN pip install . --user
+RUN rm -rf lambda_proxy setup.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+
+SHELL = /bin/bash
+
+package:
+	docker build --tag lambda-proxy:latest .
+	docker run --name lambda-proxy --volume $(shell pwd)/:/local -itd lambda-proxy:latest bash
+	docker exec -it lambda-proxy bash '/local/bin/package.sh'
+	docker stop lambda-proxy
+	docker rm lambda-proxy

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "-----------------------"
+echo "Creating lambda package"
+echo "-----------------------"
+echo "Remove uncompiled python scripts"
+# Leave module precompiles for faster Lambda startup
+cd ${PYTHONUSERBASE}/lib/python*/site-packages/
+find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
+find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+
+echo "Create archive"
+zip -r9q /tmp/package.zip *
+
+cp /tmp/package.zip /local/package.zip

--- a/lambda_proxy/app.py
+++ b/lambda_proxy/app.py
@@ -1,0 +1,80 @@
+"""app: handle requests."""
+
+from typing import Dict, Tuple, io
+
+import json
+
+from lambda_proxy.proxy import API
+
+APP = API(name="app")
+
+
+@APP.route("/", methods=["GET"], cors=True)
+def main() -> Tuple[str, str, str]:
+    """Return JSON Object."""
+    return ("OK", "text/plain", "Yo")
+
+
+@APP.route("/<regex([0-9]{2}-[a-zA-Z]{5}):regex1>", methods=["GET"], cors=True)
+def _re_one(regex1: str) -> Tuple[str, str, str]:
+    """Return JSON Object."""
+    return ("OK", "text/plain", input)
+
+
+@APP.route("/<regex([0-9]{1}-[a-zA-Z]{5}):regex2>", methods=["GET"], cors=True)
+def _re_two(regex2: str) -> Tuple[str, str, str]:
+    """Return JSON Object."""
+    return ("OK", "text/plain", input)
+
+
+@APP.route("/add", methods=["GET", "POST"], cors=True)
+def post(body) -> Tuple[str, str, str]:
+    """Return JSON Object."""
+    return ("OK", "text/plain", body)
+
+
+@APP.route("/<string:user>", methods=["GET"], cors=True)
+@APP.route("/<string:user>/<int:num>", methods=["GET"], cors=True)
+def double(user: str, num: int = 0) -> Tuple[str, str, str]:
+    """Return JSON Object."""
+    return ("OK", "text/plain", f"{user}-{num}")
+
+
+@APP.route("/kw/<string:user>", methods=["GET"], cors=True)
+def kw_method(user: str, **kwargs: Dict) -> Tuple[str, str, str]:
+    """Return JSON Object."""
+    return ("OK", "text/plain", f"{user}")
+
+
+@APP.route("/ctx/<string:user>", methods=["GET"], cors=True)
+@APP.pass_context
+@APP.pass_event
+def ctx_method(evt: Dict, ctx: Dict, user: str, num: int = 0) -> Tuple[str, str, str]:
+    """Return JSON Object."""
+    return ("OK", "text/plain", f"{user}-{num}")
+
+
+@APP.route("/json", methods=["GET"], cors=True)
+def json_handler() -> Tuple[str, str, str]:
+    """Return JSON Object."""
+    return ("OK", "application/json", json.dumps({"app": "it works"}))
+
+
+@APP.route("/binary", methods=["GET"], cors=True, payload_compression_method="gzip")
+def bin() -> Tuple[str, str, io.BinaryIO]:
+    """Return image."""
+    with open("./rpix.png", "rb") as f:
+        return ("OK", "image/png", f.read())
+
+
+@APP.route(
+    "/b64binary",
+    methods=["GET"],
+    cors=True,
+    payload_compression_method="gzip",
+    binary_b64encode=True,
+)
+def b64bin() -> Tuple[str, str, io.BinaryIO]:
+    """Return base64 encoded image."""
+    with open("./rpix.png", "rb") as f:
+        return ("OK", "image/png", f.read())

--- a/lambda_proxy/proxy.py
+++ b/lambda_proxy/proxy.py
@@ -162,6 +162,9 @@ class ApigwPath(object):
     def prefix(self):
         """Return the API prefix."""
         if self.apigw_stage:
+            if self.apigw_stage == '/$default':
+                return self.api_prefix
+
             return self.apigw_stage + self.api_prefix
         elif self.path_mapping:
             return self.path_mapping + self.api_prefix

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,0 +1,37 @@
+service: lambda-proxy-test
+
+provider:
+  name: aws
+  runtime: python3.8
+  stage: ${opt:stage, 'dev'}
+  region: ${opt:region, 'us-east-1'}
+  deploymentBucket: ${opt:bucket}
+
+  iamRoleStatements:
+  -  Effect: "Allow"
+     Action:
+       - "*"
+     Resource:
+       - arn:aws:s3:::${opt:bucket}*
+
+  apiGateway:
+    binaryMediaTypes:
+      - '*/*'
+    minimumCompressionSize: 1
+
+package:
+  artifact: package.zip
+
+functions:
+  app:
+    handler: lambda_proxy.app.APP
+    memorySize: 192
+    timeout: 10
+    environment:
+      CACHE_CONTROL: TEST
+
+    events:
+      - httpApi:
+          path: /{proxy+}
+          method: '*'
+          cors: true


### PR DESCRIPTION
Closes #39 

Working relative paths:
![image](https://user-images.githubusercontent.com/15164633/78203744-fd104c00-7454-11ea-9f78-ca284ce6a6ec.png)

Note that there's lots of scaffolding in this pr to help test that it works, but the only actual change is [here](https://github.com/vincentsarago/lambda-proxy/pull/40/files#diff-ebb942df33af9c7c3fea49c4478b5338R165-R167):

```py
    def prefix(self):
        """Return the API prefix."""
        if self.apigw_stage:
            if self.apigw_stage == '/$default':
                return self.api_prefix

            return self.apigw_stage + self.api_prefix
```