### PR TITLE
allow duplicates routes with different methods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ common: &common
     - run:
         name: run pre-commit
         command: |
-          if [[ "$CIRCLE_JOB" == "python-3.6" ]]; then
+          if [[ "$CIRCLE_JOB" == "python-3.7" ]]; then
              ~/.local/bin/pre-commit run --all-files
           fi
     - run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,18 @@
 
 repos:
     -
-        repo: 'https://github.com/ambv/black'
-        # 18.6b1
-        rev: ed50737290662f6ef4016a7ea44da78ee1eff1e2
+        repo: 'https://github.com/psf/black'
+        rev: stable
         hooks:
             - id: black
-              exclude: templates/
               args: ['--safe']
-              language_version: python3.6
+              language_version: python3.7
     -
         repo: 'https://github.com/pre-commit/pre-commit-hooks'
-        # v1.3.0
-        rev: a6209d8d4f97a09b61855ea3f1fb250f55147b8b
+        rev: v2.4.0
         hooks:
             - id: flake8
-              exclude: templates/
-              language_version: python3.6
+              language_version: python3.7
               args: [
                   # E501 let black handle all line length decisions
                   # W503 black conflicts with "line break before operator" rule
@@ -28,10 +24,17 @@ repos:
         rev: 22d3ccf6cf91ffce3b16caa946c155778f0cb20f
         hooks:
             - id: pydocstyle
-              exclude: templates/
-              language_version: python3.6
+              language_version: python3.7
               args: [
                  # Check for docstring presence only
                  '--select=D1',
                  # Don't require docstrings for tests
                  '--match=(?!test).*\.py']
+
+    -
+        repo: 'https://github.com/pre-commit/mirrors-mypy'
+        rev: v0.770
+        hooks:
+            - id: mypy
+              language_version: python3.7
+              args: [--no-strict-optional, --ignore-missing-imports]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,11 @@
 Changes
 =======
+5.2.0 (TBD)
+- change `api.routes` to list to allow path per methods 
+(e.g you can now add route with the same path but with different methods).
+- add `@app.get` `@app.post` route wrapper to add routes
+- added mypy integration
+
 5.1.1 (2020-04-03)
 - Adapt for httpAPI (#39, author kylebarron)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ def print_id(id, body):
     return ('OK', 'plain/text', id)
 ```
 
+**Note**
+
+Starting in version 5.2.0, users can now add route using `@APP.get` and `@APP.post` removing the need to add `methods=[**]`
+
 ## Binary body
 
 Starting from version 5.0.0, lambda-proxy will decode base64 encoded body on POST message.
@@ -101,11 +105,11 @@ You can also add regex parameters descriptions using special converter `regex()`
 
 example:
 ```python
-@APP.route("/app/<regex([a-z]+):regularuser>", methods=['GET'])
+@APP.get("/app/<regex([a-z]+):regularuser>")
 def print_user(regularuser):
     return ('OK', 'plain/text', f"regular {regularuser}")
 
-@APP.route("/app/<regex([A-Z]+):capitaluser>", methods=['GET'])
+@APP.get("/app/<regex([A-Z]+):capitaluser>")
 def print_user(capitaluser):
     return ('OK', 'plain/text', f"CAPITAL {capitaluser}")
 ```
@@ -115,11 +119,11 @@ def print_user(capitaluser):
 when using **regex()** you must use different variable names or the route might not show up in the documentation.
 
 ```python
-@APP.route("/app/<regex([a-z]+):user>", methods=['GET'])
+@APP.get("/app/<regex([a-z]+):user>")
 def print_user(user):
     return ('OK', 'plain/text', f"regular {user}")
 
-@APP.route("/app/<regex([A-Z]+):user>", methods=['GET'])
+@APP.get("/app/<regex([A-Z]+):user>")
 def print_user(user):
     return ('OK', 'plain/text', f"CAPITAL {user}")
 ```
@@ -146,7 +150,7 @@ Add a Cache Control header with a Time to Live (TTL) in seconds.
 from lambda_proxy.proxy import API
 APP = API(app_name="app")
 
-@APP.route('/test/tests/<id>', methods=['GET'], cors=True, cache_control="public,max-age=3600")
+@APP.get('/test/tests/<id>', cors=True, cache_control="public,max-age=3600")
 def print_id(id):
    return ('OK', 'plain/text', id)
 ```
@@ -162,7 +166,7 @@ from lambda_proxy.proxy import API
 
 APP = API(name="app")
 
-@APP.route('/test/tests/<filename>.jpg', methods=['GET'], cors=True, binary_b64encode=True)
+@APP.get('/test/tests/<filename>.jpg', cors=True, binary_b64encode=True)
 def print_id(filename):
     with open(f"{filename}.jpg", "rb") as f:
         return ('OK', 'image/jpeg', f.read())
@@ -177,9 +181,8 @@ from lambda_proxy.proxy import API
 
 APP = API(name="app")
 
-@APP.route(
+@APP.get(
    '/test/tests/<filename>.jpg',
-   methods=['GET'],
    cors=True,
    binary_b64encode=True,
    payload_compression_method="gzip"
@@ -202,7 +205,7 @@ from lambda_proxy.proxy import API
 
 APP = API(name="app")
 
-@APP.route('/test/tests/<id>', methods=['GET'], cors=True, token=True)
+@APP.get('/test/tests/<id>', cors=True, token=True)
 def print_id(id):
     return ('OK', 'plain/text', id)
 ```
@@ -216,7 +219,7 @@ from lambda_proxy.proxy import API
 
 APP = API(name="app")
 
-@APP.route('/<id>', methods=['GET'], cors=True)
+@APP.get('/<id>', cors=True)
 def print_id(id, name=None):
     return ('OK', 'plain/text', f"{id}{name}")
 ```
@@ -237,8 +240,8 @@ $ curl /000001?name=vincent
 from lambda_proxy.proxy import API
 APP = API(name="app")
 
-@APP.route('/<id>', methods=['GET'], cors=True)
-@APP.route('/<id>/<int:number>', methods=['GET'], cors=True)
+@APP.get('/<id>', cors=True)
+@APP.get('/<id>/<int:number>', cors=True)
 def print_id(id, number=None, name=None):
     return ('OK', 'plain/text', f"{id}-{name}-{number}")
 ```
@@ -267,7 +270,7 @@ from lambda_proxy.proxy import API
 
 APP = API(name="app")
 
-@APP.route("/<id>", methods=["GET"], cors=True)
+@APP.get("/<id>", cors=True)
 @APP.pass_event
 @APP.pass_context
 def print_id(ctx, evt, id):
@@ -316,9 +319,9 @@ api = API(name="api", debug=True)
 
 
 # This route won't work when using path mapping
-@api.route("/", methods=["GET"], cors=True)
+@api.get("/", cors=True)
 # This route will work only if the path mapping is set to /api
-@api.route("/api", methods=["GET"], cors=True)
+@api.get("/api", cors=True)
 def index():
     html = """<!DOCTYPE html>
     <html>
@@ -330,7 +333,7 @@ def index():
     return ("OK", "text/html", html)
 
 
-@api.route("/yo", methods=["GET"], cors=True)
+@api.get("/yo", cors=True)
 def yo():
     return ("OK", "text/plain", "YOOOOO")
 ```
@@ -358,7 +361,9 @@ $ cd lambda-proxy
 $ pip install -e .[dev]
 ```
 
-This repo is set to use pre-commit to run *flake8*, *pydocstring* and *black* ("uncompromising Python code formatter") when committing new code.
+**Python3.7 only**
+
+This repo is set to use pre-commit to run *mypy*, *flake8*, *pydocstring* and *black* ("uncompromising Python code formatter") when committing new code.
 
 ```bash
 $ pre-commit install
@@ -367,6 +372,7 @@ $ git commit -m'my change'
    black.........................Passed
    Flake8........................Passed
    Verifying PEP257 Compliance...Passed
+   mypy..........................Passed
 $ git push origin
 ```
 

--- a/example/cli.py
+++ b/example/cli.py
@@ -1,11 +1,13 @@
 """Launch server"""
 
+import base64
+
 import click
 from urllib.parse import urlparse, parse_qsl
 
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
-from app import APP
+from handler import app
 
 
 class HTTPRequestHandler(BaseHTTPRequestHandler):
@@ -20,7 +22,32 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
             "queryStringParameters": dict(parse_qsl(q.query)),
             "httpMethod": self.command,
         }
-        response = APP(request, None)
+        response = app(request, None)
+
+        self.send_response(int(response["statusCode"]))
+        for r in response["headers"]:
+            self.send_header(r, response["headers"][r])
+        self.end_headers()
+
+        if isinstance(response["body"], str):
+            self.wfile.write(bytes(response["body"], "utf-8"))
+        else:
+            self.wfile.write(response["body"])
+
+    def do_POST(self):
+        """POST requests."""
+        q = urlparse(self.path)
+        body = self.rfile.read(int(dict(self.headers).get("Content-Length")))
+        body = base64.b64encode(body).decode()
+        request = {
+            "headers": dict(self.headers),
+            "path": q.path,
+            "queryStringParameters": dict(parse_qsl(q.query)),
+            "body": body,
+            "httpMethod": self.command,
+            "isBase64Encoded": True,
+        }
+        response = app(request, None)
 
         self.send_response(int(response["statusCode"]))
         for r in response["headers"]:

--- a/example/handler.py
+++ b/example/handler.py
@@ -1,80 +1,83 @@
 """app: handle requests."""
 
-from typing import Dict, Tuple, io
+from typing import Dict, Tuple
+import typing.io
 
 import json
 
 from lambda_proxy.proxy import API
 
-APP = API(name="app")
+app = API(name="app", debug=True)
 
 
-@APP.route("/", methods=["GET"], cors=True)
+@app.get("/", cors=True)
 def main() -> Tuple[str, str, str]:
     """Return JSON Object."""
     return ("OK", "text/plain", "Yo")
 
 
-@APP.route("/<regex([0-9]{2}-[a-zA-Z]{5}):regex1>", methods=["GET"], cors=True)
+@app.get("/<regex([0-9]{2}-[a-zA-Z]{5}):regex1>", cors=True)
 def _re_one(regex1: str) -> Tuple[str, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", input)
+    return ("OK", "text/plain", regex1)
 
 
-@APP.route("/<regex([0-9]{1}-[a-zA-Z]{5}):regex2>", methods=["GET"], cors=True)
+@app.get("/<regex([0-9]{1}-[a-zA-Z]{5}):regex2>", cors=True)
 def _re_two(regex2: str) -> Tuple[str, str, str]:
     """Return JSON Object."""
-    return ("OK", "text/plain", input)
+    return ("OK", "text/plain", regex2)
 
 
-@APP.route("/add", methods=["GET", "POST"], cors=True)
-def post(body) -> Tuple[str, str, str]:
+@app.post("/people", cors=True)
+def people_post(body) -> Tuple[str, str, str]:
     """Return JSON Object."""
     return ("OK", "text/plain", body)
 
 
-@APP.route("/<string:user>", methods=["GET"], cors=True)
-@APP.route("/<string:user>/<int:num>", methods=["GET"], cors=True)
+@app.get("/people", cors=True)
+def people_get() -> Tuple[str, str, str]:
+    """Return JSON Object."""
+    return ("OK", "text/plain", "Nope")
+
+
+@app.get("/<string:user>", cors=True)
+@app.get("/<string:user>/<int:num>", cors=True)
 def double(user: str, num: int = 0) -> Tuple[str, str, str]:
     """Return JSON Object."""
     return ("OK", "text/plain", f"{user}-{num}")
 
 
-@APP.route("/kw/<string:user>", methods=["GET"], cors=True)
+@app.get("/kw/<string:user>", cors=True)
 def kw_method(user: str, **kwargs: Dict) -> Tuple[str, str, str]:
     """Return JSON Object."""
     return ("OK", "text/plain", f"{user}")
 
 
-@APP.route("/ctx/<string:user>", methods=["GET"], cors=True)
-@APP.pass_context
-@APP.pass_event
+@app.get("/ctx/<string:user>", cors=True)
+@app.pass_context
+@app.pass_event
 def ctx_method(evt: Dict, ctx: Dict, user: str, num: int = 0) -> Tuple[str, str, str]:
     """Return JSON Object."""
     return ("OK", "text/plain", f"{user}-{num}")
 
 
-@APP.route("/json", methods=["GET"], cors=True)
+@app.get("/json", cors=True)
 def json_handler() -> Tuple[str, str, str]:
     """Return JSON Object."""
     return ("OK", "application/json", json.dumps({"app": "it works"}))
 
 
-@APP.route("/binary", methods=["GET"], cors=True, payload_compression_method="gzip")
-def bin() -> Tuple[str, str, io.BinaryIO]:
+@app.get("/binary", cors=True, payload_compression_method="gzip")
+def bin() -> Tuple[str, str, typing.io.BinaryIO]:
     """Return image."""
     with open("./rpix.png", "rb") as f:
         return ("OK", "image/png", f.read())
 
 
-@APP.route(
-    "/b64binary",
-    methods=["GET"],
-    cors=True,
-    payload_compression_method="gzip",
-    binary_b64encode=True,
+@app.get(
+    "/b64binary", cors=True, payload_compression_method="gzip", binary_b64encode=True,
 )
-def b64bin() -> Tuple[str, str, io.BinaryIO]:
+def b64bin() -> Tuple[str, str, typing.io.BinaryIO]:
     """Return base64 encoded image."""
     with open("./rpix.png", "rb") as f:
         return ("OK", "image/png", f.read())

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,12 @@ with open("README.md") as f:
     readme = f.read()
 
 
-# Runtime requirements.
-inst_reqs = []
-
 extra_reqs = {"test": ["pytest", "pytest-cov", "mock"]}
 
 
 setup(
     name="lambda-proxy",
-    version="5.1.1",
+    version="5.2.0",
     description=u"Simple AWS Lambda proxy to handle API Gateway request",
     long_description=readme,
     long_description_content_type="text/markdown",
@@ -34,6 +31,5 @@ setup(
     packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
     include_package_data=True,
     zip_safe=False,
-    install_requires=inst_reqs,
     extras_require=extra_reqs,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,10 @@ exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
 max-complexity = 10
 max-line-length = 90
 
+[mypy]
+no_strict_optional = true
+ignore_missing_imports = True
+
 [testenv]
 extras = test
 commands=


### PR DESCRIPTION
closes #42 

This pr does: 
- allow duplicates routes with different methods (changing the way we store routes in the app object from dict to list)
- add `get` and `post` `@route` wrapper
- add better mypy integration
