### PR TITLE
fix new HTTP API stage handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 Changes
 =======
+5.2.1 (2020-05-04)
+- Fix bad api prefix when using new $default HTTP api stage
+
 5.2.0 (2020-04-09)
 - change `api.routes` to list to allow path per methods 
 (e.g you can now add route with the same path but with different methods).

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extra_reqs = {"test": ["pytest", "pytest-cov", "mock"]}
 
 setup(
     name="lambda-proxy",
-    version="5.2.0",
+    version="5.2.1",
     description=u"Simple AWS Lambda proxy to handle API Gateway request",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
closes #44 

FYI, API Gateway is tricky because you can have stage, api prefix (`/api/{proxy+}`), path mapping (with custom ulr), that's why there are a lot of If/else in the code. 

I think the lib should work now and return the correct `host`. The documentation on the `event` dict is not great. I tried to look at the `context` content but this will be maybe for version 7 ;-) 

cc @kylebarron 