### PR TITLE
Define override response kwargs from inside function

### DIFF
--- a/lambda_proxy/proxy.py
+++ b/lambda_proxy/proxy.py
@@ -704,15 +704,18 @@ class API(object):
                 json.dumps({"errorMessage": str(err)}),
             )
 
-        return self.response(
-            response[0],
-            response[1],
-            response[2],
-            cors=route_entry.cors,
-            accepted_methods=route_entry.methods,
-            accepted_compression=self.event["headers"].get("accept-encoding", ""),
-            compression=route_entry.compression,
-            b64encode=route_entry.b64encode,
-            ttl=route_entry.ttl,
-            cache_control=route_entry.cache_control,
-        )
+        custom_response_params = response[3] if len(response) > 3 else {}
+        response_params = {
+            **dict(
+                cors=route_entry.cors,
+                accepted_methods=route_entry.methods,
+                accepted_compression=self.event["headers"].get("accept-encoding", ""),
+                compression=route_entry.compression,
+                b64encode=route_entry.b64encode,
+                ttl=route_entry.ttl,
+                cache_control=route_entry.cache_control,
+            ),
+            **custom_response_params,
+        }
+
+        return self.response(response[0], response[1], response[2], **response_params)

--- a/lambda_proxy/proxy.py
+++ b/lambda_proxy/proxy.py
@@ -494,7 +494,7 @@ class API(object):
 
     def setup_docs(self) -> None:
         """Add default documentation routes."""
-        openapi_url = f"/openapi.json"
+        openapi_url = "/openapi.json"
 
         def _openapi() -> Tuple[str, str, str]:
             """Return OpenAPI json."""


### PR DESCRIPTION
If >= 4 items are returned from `route_entry.endpoint`, the fourth is assumed to be a `dict` with override parameters for the HTTP response. This is then combined with the default parameters for `self.response`, with values from the function overriding global parameters.