### PR TITLE
Option for custom response headers

### DIFF
--- a/lambda_proxy/proxy.py
+++ b/lambda_proxy/proxy.py
@@ -546,6 +546,7 @@ class API(object):
         b64encode: bool = False,
         ttl: int = None,
         cache_control: str = None,
+        custom_headers: dict = None,
     ):
         """Return HTTP response.
 
@@ -581,6 +582,9 @@ class API(object):
             "statusCode": status,
             "headers": {"Content-Type": content_type},
         }
+
+        if custom_headers:
+            messageData["headers"].update(custom_headers)
 
         if cors:
             messageData["headers"]["Access-Control-Allow-Origin"] = "*"

--- a/lambda_proxy/proxy.py
+++ b/lambda_proxy/proxy.py
@@ -494,7 +494,7 @@ class API(object):
 
     def setup_docs(self) -> None:
         """Add default documentation routes."""
-        openapi_url = f"/openapi.json"
+        openapi_url = "/openapi.json"
 
         def _openapi() -> Tuple[str, str, str]:
             """Return OpenAPI json."""
@@ -534,7 +534,7 @@ class API(object):
 
         self._add_route("/redoc", _redoc_ui_html, cors=True, tag=["documentation"])
 
-    def response(
+    def response(  # noqa: C901
         self,
         status: Union[int, str],
         content_type: str,

--- a/lambda_proxy/proxy.py
+++ b/lambda_proxy/proxy.py
@@ -90,6 +90,7 @@ class RouteEntry(object):
         binary_b64encode: bool = False,
         ttl=None,
         cache_control=None,
+        custom_headers: dict = None,
         description: str = None,
         tag: Tuple = None,
     ) -> None:
@@ -105,6 +106,7 @@ class RouteEntry(object):
         self.b64encode = binary_b64encode
         self.ttl = ttl
         self.cache_control = cache_control
+        self.custom_headers = custom_headers
         self.description = description or self.endpoint.__doc__
         self.tag = tag
         if self.compression and self.compression not in ["gzip", "zlib", "deflate"]:
@@ -367,6 +369,7 @@ class API(object):
         binary_encode = kwargs.pop("binary_b64encode", False)
         ttl = kwargs.pop("ttl", None)
         cache_control = kwargs.pop("cache_control", None)
+        custom_headers = kwargs.pop("custom_headers", None)
         description = kwargs.pop("description", None)
         tag = kwargs.pop("tag", None)
 
@@ -400,6 +403,7 @@ class API(object):
             binary_encode,
             ttl,
             cache_control,
+            custom_headers,
             description,
             tag,
         )
@@ -719,4 +723,5 @@ class API(object):
             b64encode=route_entry.b64encode,
             ttl=route_entry.ttl,
             cache_control=route_entry.cache_control,
+            custom_headers=route_entry.custom_headers,
         )


### PR DESCRIPTION
If `custom_headers` is supplied, it adds arbitrary key-value pairs from the `dict` to the response message object.

Using a `dict` for `custom_headers` is ideal, because it essentially removes the need for `ttl` and `cache_control`, though they are kept for backwards compatibility.